### PR TITLE
TEST - Nm/forked group state

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -1549,7 +1549,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 12)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_forked_group_state() {
         let bo = new_test_client().await;
         let alix = new_test_client().await;
@@ -1637,7 +1637,5 @@ mod tests {
             .find_messages(list_messages_options.clone())
             .unwrap();
         assert_eq!(alix_messages.len(), 7);
-
-        assert_eq!(bo_message_counter.message_count(), 7)
     }
 }

--- a/bindings_node/Cargo.lock
+++ b/bindings_node/Cargo.lock
@@ -2616,7 +2616,7 @@ dependencies = [
 [[package]]
 name = "openmls"
 version = "0.5.0"
-source = "git+https://github.com/xmtp/openmls?rev=606bf92#606bf929e133422fe9737ba7089f6e63a4738300"
+source = "git+https://github.com/xmtp/openmls?rev=99b2d5e7d0e034ac57644395e2194c5a102afb9a#99b2d5e7d0e034ac57644395e2194c5a102afb9a"
 dependencies = [
  "backtrace",
  "itertools 0.10.5",
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?rev=606bf92#606bf929e133422fe9737ba7089f6e63a4738300"
+source = "git+https://github.com/xmtp/openmls?rev=99b2d5e7d0e034ac57644395e2194c5a102afb9a#99b2d5e7d0e034ac57644395e2194c5a102afb9a"
 dependencies = [
  "ed25519-dalek",
  "openmls_traits",
@@ -2651,7 +2651,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?rev=606bf92#606bf929e133422fe9737ba7089f6e63a4738300"
+source = "git+https://github.com/xmtp/openmls?rev=99b2d5e7d0e034ac57644395e2194c5a102afb9a#99b2d5e7d0e034ac57644395e2194c5a102afb9a"
 dependencies = [
  "hex",
  "log",
@@ -2664,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?rev=606bf92#606bf929e133422fe9737ba7089f6e63a4738300"
+source = "git+https://github.com/xmtp/openmls?rev=99b2d5e7d0e034ac57644395e2194c5a102afb9a#99b2d5e7d0e034ac57644395e2194c5a102afb9a"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -2688,7 +2688,7 @@ dependencies = [
 [[package]]
 name = "openmls_test"
 version = "0.1.0"
-source = "git+https://github.com/xmtp/openmls?rev=606bf92#606bf929e133422fe9737ba7089f6e63a4738300"
+source = "git+https://github.com/xmtp/openmls?rev=99b2d5e7d0e034ac57644395e2194c5a102afb9a#99b2d5e7d0e034ac57644395e2194c5a102afb9a"
 dependencies = [
  "ansi_term",
  "openmls_rust_crypto",
@@ -2703,7 +2703,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?rev=606bf92#606bf929e133422fe9737ba7089f6e63a4738300"
+source = "git+https://github.com/xmtp/openmls?rev=99b2d5e7d0e034ac57644395e2194c5a102afb9a#99b2d5e7d0e034ac57644395e2194c5a102afb9a"
 dependencies = [
  "serde",
  "tls_codec 0.4.2-pre.1",

--- a/xmtp_id/src/associations/association_log.rs
+++ b/xmtp_id/src/associations/association_log.rs
@@ -187,8 +187,6 @@ impl IdentityAction for AddAssociation {
 
         let new_member = Member::new(new_member_address, Some(existing_entity_id));
 
-        println!("Adding new entity to state {:?}", &new_member);
-
         Ok(existing_state.add(new_member))
     }
 

--- a/xmtp_mls/src/api/identity.rs
+++ b/xmtp_mls/src/api/identity.rs
@@ -119,7 +119,10 @@ where
         &self,
         account_addresses: Vec<String>,
     ) -> Result<AddressToInboxIdMap, WrappedApiError> {
-        log::info!("Asked for account addresses: {:?}", &account_addresses);
+        log::info!(
+            "Getting inbox_ids for account addresses: {:?}",
+            &account_addresses
+        );
         let result = self
             .api_client
             .get_inbox_ids(GetInboxIdsRequest {

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -101,7 +101,6 @@ where
         if let Some(association_state) =
             StoredAssociationState::read_from_cache(conn, inbox_id.to_string(), last_sequence_id)?
         {
-            log::debug!("Loaded association state from cache");
             return Ok(association_state);
         }
 
@@ -117,7 +116,6 @@ where
             last_sequence_id,
             association_state.clone(),
         )?;
-        log::debug!("Wrote association state to cache");
 
         Ok(association_state)
     }
@@ -245,11 +243,6 @@ where
         new_group_membership: &GroupMembership,
         membership_diff: &MembershipDiff<'_>,
     ) -> Result<InstallationDiff, InstallationDiffError> {
-        log::info!(
-            "Getting installation diff. Old: {:?}. New {:?}",
-            old_group_membership,
-            new_group_membership
-        );
         let added_and_updated_members = membership_diff
             .added_inboxes
             .iter()


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add test for forked group state with message sync assertions
- Adds `test_forked_group_state` to [bindings_ffi/src/mls.rs](https://github.com/prassoai/libxmtp/pull/17/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f), covering group creation, multi-participant message sending, syncing, and message count assertions.
- Derives `Clone` on `FfiListMessagesOptions` and `FfiDeliveryStatus` to support the new test.
- Upgrades several log levels in `sync.rs` from debug to info/warn and removes noisy debug/println statements across `association_log.rs` and `identity_updates.rs`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://primary.lb.app.staging.web.nonprod.prasso.ai">Macroscope</a> summarized 6797fd5.</sup>
<!-- Macroscope's review summary ends here -->

<details>
<summary>🐞</summary>

> **Summarization**
> • [Workflow](https://cloud.temporal.io/namespaces/macroscope-nonprod.wiqje/workflows/workspace%2Fgithub_organization%2F139157646%2Frepo%2F961074513%2Fpr%2F17%2Fhead%2F6797fd55f2e1646a398dbbf67190130854b001d2%2Fmerge_base%2F2715ea26f63c0c0daea8725de513d3b15baff1a5%2FPullRequestSummaryUpdaterWorkflow/019ce897-cb96-744c-bb8b-237e4fefefe3/history)
</details>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->